### PR TITLE
feat: Add CI/CD with GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Python 3.12
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: 3.12
 
@@ -26,7 +26,7 @@ jobs:
 
     - name: Load cached venv
       id: cached-poetry-dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: .venv
         key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,4 +39,4 @@ jobs:
       run: poetry run ruff check .
 
     - name: Run smoke test
-      run: timeout 5s poetry run streamlit run app.py --server.port 8501 --server.headless true
+      run: timeout 5s poetry run streamlit run app.py --server.port 8501 --server.headless true || [ $? -eq 124 ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         python-version: 3.12
 
     - name: Install Poetry
-      uses: snok/install-poetry@v1
+      uses: snok/install-poetry@v1.3.4
       with:
         virtualenvs-create: true
         virtualenvs-in-project: true
@@ -36,11 +36,7 @@ jobs:
       run: poetry install --no-interaction --no-root
 
     - name: Lint with ruff
-      run: |
-        poetry run ruff check .
+      run: poetry run ruff check .
 
     - name: Run smoke test
-      run: |
-        poetry run streamlit run app.py --server.port 8501 &
-        sleep 5
-        kill %1
+      run: timeout 5s poetry run streamlit run app.py --server.port 8501 --server.headless true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Python 3.12
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.12
+
+    - name: Install Poetry
+      uses: snok/install-poetry@v1
+      with:
+        virtualenvs-create: true
+        virtualenvs-in-project: true
+
+    - name: Load cached venv
+      id: cached-poetry-dependencies
+      uses: actions/cache@v2
+      with:
+        path: .venv
+        key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
+
+    - name: Install dependencies
+      if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
+      run: poetry install --no-interaction --no-root
+
+    - name: Lint with ruff
+      run: |
+        poetry run ruff check .
+
+    - name: Run smoke test
+      run: |
+        poetry run streamlit run app.py --server.port 8501 &
+        sleep 5
+        kill %1

--- a/literaturereviewbot/prompts/literature_review.py
+++ b/literaturereviewbot/prompts/literature_review.py
@@ -23,8 +23,8 @@ def generate_prompt(question):
     for i, doc in enumerate(documents):
         try:
             content = doc.page_content if hasattr(doc, "page_content") else ""
-        except:
-            print(doc)
+        except Exception as e:
+            print(f"Error processing document: {doc}, error: {e}")
             content = ""
             continue
         messages.append(

--- a/literaturereviewbot/search_pubmed.py
+++ b/literaturereviewbot/search_pubmed.py
@@ -42,7 +42,7 @@ def parse_article(pmid, details):
         abstract_text = details["PubmedArticle"][0]["MedlineCitation"]["Article"][
             "Abstract"
         ]["AbstractText"][0]
-    except:
+    except (KeyError, IndexError):
         return None
     ##################
     ## article details
@@ -71,7 +71,7 @@ def parse_article(pmid, details):
         pub_day = pub_date["Day"]
         pages = article["Pagination"].get("StartPage", "No pages")
         citation = f"{author_str}. {title}. {journal_title}. {pub_year} {pub_month} {pub_day};{journal_volume}({journal_issue}):{pages}. PMID: {pmid}."
-    except:
+    except (KeyError, IndexError):
         citation = f"{title}. {journal_title}. PMID: {pmid}."
 
     return citation, abstract_text


### PR DESCRIPTION
This commit adds a basic CI/CD pipeline using GitHub Actions. The workflow is defined in `.github/workflows/ci.yml` and it includes the following steps:
- Triggers on push to `main` and pull requests to `main`.
- Sets up a Python environment.
- Installs Poetry and project dependencies.
- Runs `ruff` to lint the code.
- Runs a smoke test to ensure the Streamlit app can be started.